### PR TITLE
Add facilities for API Gateway-formatted requests

### DIFF
--- a/src/ring_aws_lambda_adapter/core.clj
+++ b/src/ring_aws_lambda_adapter/core.clj
@@ -28,6 +28,39 @@
      (try
        (Integer/parseInt (get-in event [:headers :X-Forwarded-Port]))
        (catch NumberFormatException e nil))
+     :body           (-> (get event :body {})
+                         json/write-str
+                         (.getBytes)
+                         io/input-stream)
+     :server-name    host
+     :remote-addr    (get event :source-ip "")
+     :uri            (interpolate-path (get event :path {})
+                                       (get event :resource-path ""))
+     :query-string   (codec/form-encode (get event :query-string {}))
+     :scheme         (keyword
+                      (get-in event [:headers :X-Forwarded-Proto]))
+     :request-method (keyword
+                      (str/lower-case (get event :http-method "")))
+     :protocol       (format "HTTP/%s" http-version)
+     :headers        (into {} (map (fn -header-keys [[k v]]
+                                     [(str/lower-case (name k)) v])
+                                   (:headers event)))
+     :event          event
+     :context        context}))
+
+(defn proxy-event->request
+  "Transform lambda input of an API Proxy request to Ring requests.
+   Has two extra properties:
+   :event - the lambda input
+   :context - an instance of a lambda context
+              http://docs.aws.amazon.com/lambda/latest/dg/java-context-object.html"
+  [event context]
+  (let [[http-version host]
+        (str/split (get-in event [:headers :Via] "") #" ")]
+    {:server-port
+     (try
+       (Integer/parseInt (get-in event [:headers :X-Forwarded-Port]))
+       (catch NumberFormatException e nil))
      :body           (get event :body)
      :server-name    host
      :uri            (get event :path "/")
@@ -64,6 +97,12 @@
        (catch Exception e
          json)))
 
+(defn maybe-encode-json [json]
+  (try
+    (json/write-str json)
+      (catch Exception e
+        json)))
+
 (defn wrap-response [response]
   (if (map? response)
     (update-in response
@@ -77,21 +116,41 @@
   non-200 responses"
   [handler options in out context]
   (let [event (json/read (io/reader in)
-                         :key-fn keyword)
+                          :key-fn keyword)
         request (event->request event context)
+        response (-> request
+                     handler
+                     wrap-response)]
+    (if (= (:status response) 200)
+      (with-open [w (io/writer out)]
+        (json/write response w))
+      (throw (Exception. (json/write-str response))))))
+
+(defn handle-proxy-request
+  "Handle a lambda invocation as a ring request. Writes ring response as JSON to
+  `out` for 200 responses, raises an exception with ring response as JSON for
+  non-200 responses"
+  [handler options in out context]
+  (let [event (json/read (io/reader in)
+                         :key-fn keyword)
+        request (proxy-event->request event context)
         response (-> request
                      handler
                      wrap-response)
         status (:status response)
+        body   (:body response)
         formatted (-> response
                       (assoc :statusCode status)
-                      (dissoc :status))]
+                      (assoc :body (maybe-encode-json body))
+                      (select-keys [:statusCode :headers :body]))]
     (with-open [w (io/writer out)]
       (json/write formatted w))))
 
 (defmacro defhandler
   "A ring handler for AWS Lambda and AWS API Gateway"
-  [name handler options]
+  [name handler {:keys [api-proxy] :as options}]
   `(deflambdafn ~name
      [in# out# context#]
-     (handle-request ~handler ~options in# out# context#)))
+     (if ~api-proxy
+       (handle-proxy-request ~handler ~options in# out# context#)
+       (handle-request ~handler ~options in# out# context#))))

--- a/src/ring_aws_lambda_adapter/core.clj
+++ b/src/ring_aws_lambda_adapter/core.clj
@@ -81,11 +81,13 @@
         request (event->request event context)
         response (-> request
                      handler
-                     wrap-response)]
-    (if (= (:status response) 200)
-      (with-open [w (io/writer out)]
-        (json/write response w))
-      (throw (Exception. (json/write-str response))))))
+                     wrap-response)
+        status (:status response)
+        formatted (-> response
+                      (assoc :statusCode status)
+                      (dissoc :status))]
+    (with-open [w (io/writer out)]
+      (json/write formatted w))))
 
 (defmacro defhandler
   "A ring handler for AWS Lambda and AWS API Gateway"

--- a/src/ring_aws_lambda_adapter/core.clj
+++ b/src/ring_aws_lambda_adapter/core.clj
@@ -28,19 +28,14 @@
      (try
        (Integer/parseInt (get-in event [:headers :X-Forwarded-Port]))
        (catch NumberFormatException e nil))
-     :body           (-> (get event :body {})
-                         json/write-str
-                         (.getBytes)
-                         io/input-stream)
+     :body           (get event :body)
      :server-name    host
-     :remote-addr    (get event :source-ip "")
-     :uri            (interpolate-path (get event :path {})
-                                       (get event :resource-path ""))
-     :query-string   (codec/form-encode (get event :query-string {}))
+     :uri            (get event :path "/")
+     :query-params   (get event :queryStringParameters {})
      :scheme         (keyword
                       (get-in event [:headers :X-Forwarded-Proto]))
      :request-method (keyword
-                      (str/lower-case (get event :http-method "")))
+                      (str/lower-case (get event :httpMethod "")))
      :protocol       (format "HTTP/%s" http-version)
      :headers        (into {} (map (fn -header-keys [[k v]]
                                      [(str/lower-case (name k)) v])
@@ -82,7 +77,7 @@
   non-200 responses"
   [handler options in out context]
   (let [event (json/read (io/reader in)
-                          :key-fn keyword)
+                         :key-fn keyword)
         request (event->request event context)
         response (-> request
                      handler


### PR DESCRIPTION
AWS's API Gateway adds the ability to just proxy everything through to a Lambda function, but changes the event context slightly and requires a slightly different response format. This adds functionality to correctly parse that event and return the necessary response.